### PR TITLE
"Fixed" chest type not implemented warning with implemented chest types

### DIFF
--- a/botcraft/src/Game/Inventory/InventoryManager.cpp
+++ b/botcraft/src/Game/Inventory/InventoryManager.cpp
@@ -288,12 +288,13 @@ namespace Botcraft
         InventoryType type = InventoryType::Default;
         if (msg.GetType() == "minecraft:chest")
         {
+            //std::cout << (int)msg.GetNumberOfSlots() << std::endl;
             switch (msg.GetNumberOfSlots())
             {
-            case 62:
+            case 9*3://62:
                 type = InventoryType::Generic9x3;
                 break;
-            case 89:
+            case 9*6://89:
                 type = InventoryType::Generic9x6;
                 break;
             default:

--- a/botcraft/src/Game/Inventory/InventoryManager.cpp
+++ b/botcraft/src/Game/Inventory/InventoryManager.cpp
@@ -288,13 +288,12 @@ namespace Botcraft
         InventoryType type = InventoryType::Default;
         if (msg.GetType() == "minecraft:chest")
         {
-            //std::cout << (int)msg.GetNumberOfSlots() << std::endl;
             switch (msg.GetNumberOfSlots())
             {
-            case 9*3://62:
+            case 9*3:
                 type = InventoryType::Generic9x3;
                 break;
-            case 9*6://89:
+            case 9*6:
                 type = InventoryType::Generic9x6;
                 break;
             default:


### PR DESCRIPTION
Ok, so I do this as a pull request.

There is probably a reason why it expects to have 62 slots in a 9x3 chest and 89 slots in a 9x6, but in my case (1.12.2) it just caused the program to print out a warning while actually working as intended.
I might have broken something I have no idea about, but I don't know about anything.