### PR TITLE
Add Ping/Pong in Connection Client

### DIFF
--- a/botcraft/include/botcraft/Game/ConnectionClient.hpp
+++ b/botcraft/include/botcraft/Game/ConnectionClient.hpp
@@ -39,6 +39,7 @@ namespace Botcraft
 
     protected:
         virtual void Handle(ProtocolCraft::Message& msg) override;
+        virtual void Handle(ProtocolCraft::ClientboundPingPacket& msg) override;
         virtual void Handle(ProtocolCraft::ClientboundLoginDisconnectPacket& msg) override;
 #if PROTOCOL_VERSION < 755 /* < 1.17 */
         virtual void Handle(ProtocolCraft::ClientboundContainerAckPacket& msg) override;

--- a/botcraft/src/Game/ConnectionClient.cpp
+++ b/botcraft/src/Game/ConnectionClient.cpp
@@ -80,6 +80,12 @@ namespace Botcraft
 
     }
 
+    void ConnectionClient::Handle(ClientboundPingPacket &msg) {
+        std::shared_ptr<ServerboundPongPacket> reply_message = std::make_shared<ServerboundPongPacket>();
+        reply_message->SetId_(msg.GetId_());
+        network_manager->Send(reply_message);
+    }
+
     void ConnectionClient::Handle(ClientboundLoginDisconnectPacket& msg)
     {
 #if PROTOCOL_VERSION < 765 /* < 1.20.3 */


### PR DESCRIPTION
Ping/Pongs are part of the Minecraft protocol and I kind of got tired of inheriting the entire client just to add this one handler for them every time. I use servers which enforce this and I figured since it is also a vanilla feature it might be worth just pushing this upstream from my own private projects. Without this the client times out on some more modern server software with very misleading error messages.

This was originally part of the larger physics PR I was working on last year, but since you completed that and did a great job this was the one thing missing from my work that didn't end up in Botcraft itself.

Thanks for all your hard work <3