### PR TITLE
Changed LookAt to update LocalPlayer's rotation and wait for packet to send.

### DIFF
--- a/botcraft/include/botcraft/AI/Tasks/PathfindingTask.hpp
+++ b/botcraft/include/botcraft/AI/Tasks/PathfindingTask.hpp
@@ -55,12 +55,12 @@ namespace Botcraft
     /// @param client The client performing the action
     /// @param target The target to look at
     /// @param set_pitch If false, only the yaw will be changed
-    /// @return Always return Success
+    /// @return Success if rotation was sent, Failure otherwise
     Status LookAt(BehaviourClient& client, const Vector3<double>& target, const bool set_pitch = true);
 
     /// @brief Same thing as LookAt, but reads its parameters from the blackboard
     /// @param client The client performing the action
-    /// @return Always return Success
+    /// @return Success if rotation was sent, Failure otherwise
     Status LookAtBlackboard(BehaviourClient& client);
 
     /// @brief Make the current player fly (as in creative/spectator mode, NOT WITH ELYTRA)

--- a/botcraft/src/AI/Tasks/PathfindingTask.cpp
+++ b/botcraft/src/AI/Tasks/PathfindingTask.cpp
@@ -1551,12 +1551,10 @@ namespace Botcraft
         std::shared_ptr<LocalPlayer> local_player = client.GetLocalPlayer();
         local_player->LookAt(target, set_pitch);
 
-        std::shared_ptr<ProtocolCraft::ServerboundMovePlayerPacketRot> rot = std::make_shared<ProtocolCraft::ServerboundMovePlayerPacketRot>();
-        rot->SetOnGround(local_player->GetOnGround());
-        rot->SetYRot(local_player->GetYaw());
-        rot->SetXRot(local_player->GetPitch());
-
-        client.GetNetworkManager()->Send(rot);
+        local_player->AddInputsForward(0.0f);
+        if (!Utilities::YieldForCondition([&] {
+            return !local_player->GetDirtyInputs();
+        }, client, 250)) return Status::Failure;
 
         return Status::Success;
     }


### PR DESCRIPTION
This is helpful because sending repeated PlayerPosRot packets flags anticheat and is largely unnecessary. This could also be implemented by making LookAt just modify the LocalPlayer and then having some other task which waits for PhysicsManager to send its packet. I can implement the second one if that sounds preferable to you, both are extraordinarily easy to do.

Normally I would just make my own LookAtPacketless task, but other tasks rely on the vanilla LookAt task and make them unusable for my application because of it.