### PR TITLE
Fix nullptr string construction on version 1.12.2

### DIFF
--- a/botcraft/src/Game/World/World.cpp
+++ b/botcraft/src/Game/World/World.cpp
@@ -1084,7 +1084,7 @@ namespace Botcraft
         // As we are in a loaded chunk, nullptr means it's in an empty section
         // (or the chunk position was invalid but we know it's valid given how it's constructed above)
         // --> return air block instead of nullptr
-        return output != nullptr ? output : AssetsManager::getInstance().GetBlockstate(0);
+        return output != nullptr ? output : AssetsManager::getInstance().GetBlockstate(BlockstateId{});
     }
 
 #if PROTOCOL_VERSION < 719 /* < 1.16 */


### PR DESCRIPTION
Previously passing `0` would lead to `GetBlockstate` being called with `nullptr`.