### PR TITLE
Change the hotbar selection

### DIFF
--- a/botcraft/include/botcraft/Game/Inventory/InventoryManager.hpp
+++ b/botcraft/include/botcraft/Game/Inventory/InventoryManager.hpp
@@ -45,10 +45,14 @@ namespace Botcraft
         short GetFirstOpenedWindowId() const;
         std::shared_ptr<Window> GetPlayerInventory() const;
         short GetIndexHotbarSelected() const;
+        /// @brief Does not send a packet, just updates inventory state.
+        /// To send the packet, use ManagersClient::SetHotbarSelection(index).
+        void SetIndexHotbarSelected(const short index);
         ProtocolCraft::Slot GetHotbarSelected() const;
         ProtocolCraft::Slot GetOffHand() const;
         ProtocolCraft::Slot GetCursor() const;
         void EraseInventory(const short window_id);
+
 #if PROTOCOL_VERSION < 755 /* < 1.17 */
         TransactionState GetTransactionState(const short window_id, const int transaction_id) const;
         void AddPendingTransaction(const InventoryTransaction& transaction);
@@ -67,7 +71,6 @@ namespace Botcraft
 #endif
 
     private:
-        void SetHotbarSelected(const short index);
         void SetCursor(const ProtocolCraft::Slot& c);
 
         void AddInventory(const short window_id, const InventoryType window_type);

--- a/botcraft/include/botcraft/Game/ManagersClient.hpp
+++ b/botcraft/include/botcraft/Game/ManagersClient.hpp
@@ -40,6 +40,8 @@ namespace Botcraft
         bool GetAutoRespawn() const;
         void SetAutoRespawn(const bool b);
 
+        void SetHotbarSelection(const short index);
+
         // Set the right transaction id, add it to the inventory manager,
         // update the next transaction id and send it to the server
         // return the id of the transaction

--- a/botcraft/src/Game/Inventory/InventoryManager.cpp
+++ b/botcraft/src/Game/Inventory/InventoryManager.cpp
@@ -67,6 +67,12 @@ namespace Botcraft
         return index_hotbar_selected;
     }
 
+    void InventoryManager::SetIndexHotbarSelected(const short index)
+    {
+        std::scoped_lock<std::shared_mutex> lock(inventory_manager_mutex);
+        index_hotbar_selected = index;
+    }
+
     short InventoryManager::GetFirstOpenedWindowId() const
     {
         std::shared_lock<std::shared_mutex> lock(inventory_manager_mutex);
@@ -226,12 +232,6 @@ namespace Botcraft
         pending_transactions[window_id] = std::map<short, InventoryTransaction >();
         transaction_states[window_id] = std::map<short, TransactionState>();
 #endif
-    }
-
-    void InventoryManager::SetHotbarSelected(const short index)
-    {
-        std::scoped_lock<std::shared_mutex> lock(inventory_manager_mutex);
-        index_hotbar_selected = index;
     }
 
     Slot InventoryManager::GetCursor() const
@@ -585,7 +585,8 @@ namespace Botcraft
     void InventoryManager::Handle(ClientboundSetHeldSlotPacket& packet)
 #endif
     {
-        SetHotbarSelected(packet.GetSlot());
+        std::scoped_lock<std::shared_mutex> lock(inventory_manager_mutex);
+        index_hotbar_selected = packet.GetSlot();
     }
 
 #if PROTOCOL_VERSION < 755 /* < 1.17 */

--- a/botcraft/src/Game/Inventory/InventoryManager.cpp
+++ b/botcraft/src/Game/Inventory/InventoryManager.cpp
@@ -647,8 +647,7 @@ namespace Botcraft
 #if PROTOCOL_VERSION > 767 /* > 1.21.1 */
     void InventoryManager::Handle(ClientboundSetCursorItemPacket& packet)
     {
-        // Not sure about this one, I can't figure out when it's sent by the server
-        SetSlot(Window::PLAYER_INVENTORY_INDEX, Window::INVENTORY_HOTBAR_START + index_hotbar_selected, packet.GetContents());
+        SetCursor(packet.GetContents());
     }
 
     void InventoryManager::Handle(ProtocolCraft::ClientboundSetPlayerInventoryPacket& packet)

--- a/botcraft/src/Game/ManagersClient.cpp
+++ b/botcraft/src/Game/ManagersClient.cpp
@@ -97,6 +97,14 @@ namespace Botcraft
         return day_time;
     }
 
+    void ManagersClient::SetHotbarSelection(const short index)
+    {
+        inventory_manager->SetIndexHotbarSelected(index);
+        ServerboundSetCarriedItemPacket packet;
+        packet.SetSlot(index);
+        network_manager->Send(std::make_shared<ServerboundSetCarriedItemPacket>(packet));
+    }
+
     int ManagersClient::SendInventoryTransaction(const std::shared_ptr<ServerboundContainerClickPacket>& transaction)
     {
         InventoryTransaction inventory_transaction = inventory_manager->PrepareTransaction(transaction);


### PR DESCRIPTION
When the desired item is already in the hotbar, it is not necessary to move any items around. The client can tell the server the new selected hotbar slot and use the item there.