### PR TITLE
Screenshot via callback

### DIFF
--- a/botcraft/include/botcraft/Renderer/RenderingManager.hpp
+++ b/botcraft/include/botcraft/Renderer/RenderingManager.hpp
@@ -74,7 +74,7 @@ namespace Botcraft
 
             // Take a screenshot of the current frame and save it to path
             void Screenshot(const std::string& path);
-	    void Screenshot(std::function<void(const int, const int, const std::vector<unsigned char> &, void *arg)> callback);
+	    void Screenshot(std::function<void(const int, const int, const std::vector<unsigned char> &, void *arg)> callback, void *arg);
 
             void SetCurrentBehaviourTree(const BaseNode* root) const;
             void ResetBehaviourState() const;

--- a/botcraft/src/Renderer/RenderingManager.cpp
+++ b/botcraft/src/Renderer/RenderingManager.cpp
@@ -389,13 +389,15 @@ namespace Botcraft
         {
             screenshot_path = path;
 	    screenshot_callback.reset();
+	    screenshot_arg = nullptr;
             take_screenshot = true;
         }
 
-        void RenderingManager::Screenshot(std::function<void(const int, const int, const std::vector<unsigned char> &, void *args)> callback)
+        void RenderingManager::Screenshot(std::function<void(const int, const int, const std::vector<unsigned char> &, void *args)> callback, void *arg)
         {
             screenshot_path.clear();
 	    screenshot_callback = callback;
+	    screenshot_arg = arg;
             take_screenshot = true;
         }
 


### PR DESCRIPTION
This change allows a user to invoke a screenshot via a callback. That way it won't end up in a file but can be postprocessed by the invoker before e.g. storing it as a jpeg or so.