### PR TITLE
Assignment to a shared_ptr is not atomic (due to the reference counting) so locking is required.

### DIFF
--- a/botcraft/include/botcraft/AI/TemplatedBehaviourClient.hpp
+++ b/botcraft/include/botcraft/AI/TemplatedBehaviourClient.hpp
@@ -284,9 +284,12 @@ namespace Botcraft
                 // We need to update the tree with the new one
                 catch (const SwapTree&)
                 {
-                    tree = new_tree;
-                    new_tree = nullptr;
-                    swap_tree = false;
+		    {
+                        std::lock_guard<std::mutex> behaviour_guard(behaviour_mutex);
+                        tree = new_tree;
+                        new_tree = nullptr;
+                        swap_tree = false;
+		    }
                     OnTreeChanged(tree.get());
                     blackboard.Reset(new_blackboard);
                     continue;


### PR DESCRIPTION
This patch may resolve the problem. I'm not 100% confident as there may be other places need locking when accessing the tree variable.