### PR TITLE
fix: free OpenSSL cipher contexts in AESEncrypter::Init to prevent memory leak

### DIFF
--- a/botcraft/src/Network/AESEncrypter.cpp
+++ b/botcraft/src/Network/AESEncrypter.cpp
@@ -105,9 +105,21 @@ namespace Botcraft
 #endif
         RSA_free(rsa);
 
+        if (encryption_context != nullptr)
+        {
+            EVP_CIPHER_CTX_free(encryption_context);
+            encryption_context = nullptr;
+        }
+
         encryption_context = EVP_CIPHER_CTX_new();
         EVP_EncryptInit_ex(encryption_context, EVP_aes_128_cfb8(), nullptr, raw_shared_secret.data(), raw_shared_secret.data());
 
+        if (decryption_context != nullptr)
+        {
+            EVP_CIPHER_CTX_free(decryption_context);
+            decryption_context = nullptr;
+        }
+        
         decryption_context = EVP_CIPHER_CTX_new();
         EVP_DecryptInit_ex(decryption_context, EVP_aes_128_cfb8(), nullptr, raw_shared_secret.data(), raw_shared_secret.data());
 


### PR DESCRIPTION
Problem
While reviewing the network layer, I noticed that `AESEncrypter::Init` creates new cipher contexts using `EVP_CIPHER_CTX_new()` without cleaning up existing resources if the instance is already initialized. 

If a bot client experiences a connection drop and triggers a reconnection flow (or re-runs the handshake protocol), `Init()` is called again on the same `AESEncrypter` instance. This causes `encryption_context` and `decryption_context` raw pointers to be overwritten, resulting in a progressive memory leak of OpenSSL allocations inside long-running bot instances.

Solution
- Added explicit safe-checks before instantiating new contexts.
- If `encryption_context` or `decryption_context` are not `nullptr`, they are now properly released via `EVP_CIPHER_CTX_free()` and reset to `nullptr` before receiving new pointer addresses.

Tested on Arch Linux (OpenSSL 3.x), builds successfully with no regressions.